### PR TITLE
dataset as input from url

### DIFF
--- a/inst/woprVision/server.R
+++ b/inst/woprVision/server.R
@@ -4,11 +4,12 @@ shinyServer(
     # reactive values
     rv <- reactiveValues()
     
+    # input dataset from url
     observe({
       query <- parseQueryString(session$clientData$url_search)
       if (!is.null(query[['data_select']])) {
         
-        data_select <- query[['data_select']]
+        data_select <- gsub('_', ' ', query[['data_select']])
         
         if(data_select %in% row.names(version_info)){
           updateSelectInput(session, "data_select",

--- a/inst/woprVision/server.R
+++ b/inst/woprVision/server.R
@@ -1,17 +1,32 @@
 shinyServer(
   function(input, output, session){
-
+    
     # reactive values
     rv <- reactiveValues()
-
+    
+    observe({
+      query <- parseQueryString(session$clientData$url_search)
+      if (!is.null(query[['data_select']])) {
+        
+        data_select <- query[['data_select']]
+        
+        if(data_select %in% row.names(version_info)){
+          updateSelectInput(session, "data_select",
+                            choices = data_select,
+                            selected = data_select
+          )
+        }
+      }  
+    })
+    
     ##-- observe new data selected --##
     observeEvent(input$data_select, {
-
+      
       # disconnect from last database
       if(!is.null(rv$sql)) {
         DBI::dbDisconnect(rv$sql)
       }
-
+      
       # cleanup environment
       rv$sql <-
         rv$mastergrid <-
@@ -24,44 +39,44 @@ shinyServer(
         rv$N <-
         rv$agesexid <- NULL
       gc()
-
+      
       # remove local_tiles
       if('tiles' %in% resourcePaths()) removeResourcePath('tiles')
-
+      
       # reset pointpoly
       updateRadioButtons(session=session, inputId='pointpoly', selected='Selected Point')
-
+      
       # disable submit
       shinyjs::disable('submit')
-
+      
       # update version
       rv$country <- unlist(strsplit(input$data_select,' '))[1]
       rv$version <- unlist(strsplit(input$data_select,' '))[2]
-
+      
       # palette
       if(input$data_select %in% names(palette)){
         rv$palette <- palette[[input$data_select]]
       } else {
         rv$palette <- palette[['default']]
       }
-
+      
       rv$bins <- c(rv$palette$bins[-length(rv$palette$bins)],
                    round(max(rv$palette$bins[length(rv$palette$bins)-1] + diff(rv$palette$bins[c(length(rv$palette$bins)-2, length(rv$palette$bins)-1)]),
                              version_info[input$data_select,'popmax'])))
-
+      
       rv$pal <- leaflet::colorBin(palette=rv$palette$cols[2:nrow(rv$palette)],
                                   bins=rv$bins,
                                   na.color=rv$palette$cols[1],
                                   domain=1:1000, pretty=F, alpha=T, reverse=F)
-
+      
       # update urls
       rv$data_readme_url <- file.path('https://wopr.worldpop.org/readme',
                                       version_info[input$data_select,'readme'])
       rv$wopr_url <- version_info[input$data_select, 'url'] # paste0('https://wopr.worldpop.org/?',file.path(rv$country,'Population',rv$version))
-
-
-
-
+      
+      
+      
+      
       # update agesex choices
       if( sum(agesex[[input$data_select]][,c('f1','m1')]) == 0 ){
         shinyWidgets::updateSliderTextInput(session, 'female_select',
@@ -78,14 +93,14 @@ shinyServer(
                                             choices = agesex_choices,
                                             selected = c('<1','80+'))
       }
-
+      
       # deactivation message
       if(version_info[input$data_select,'deprecated']){
         showModal(modalDialog(HTML(paste0(input$data_select,rv$dict[["lg_annoyingmessage"]], '<a href="',rv$wopr_url,'" target="blank">',rv$wopr_url,'</a>')),
                               title=rv$dict[["lg_annoyingmessage_title"]],
                               footer=tagList(modalButton(rv$dict[["lg_thks"]]))))
       }
-
+      
       # local SQL mode
       if(version_info[input$data_select,'local_sql']){
         message(paste0(rv$dict[["lg_localSQL"]],input$data_select,'.'))
@@ -93,19 +108,19 @@ shinyServer(
                                      version_info[input$data_select, 'local_sql_path'])
         rv$mastergrid <- raster::raster(version_info[input$data_select, 'local_mastergrid_path'])
       }
-
+      
       # local tiles
       if(version_info[input$data_select, 'local_tiles']){
         message(paste0(rv$dict[["lg_localtiles"]],input$data_select,'.'))
         addResourcePath('tiles', version_info[input$data_select, 'local_tiles_path'])
       }
-
+      
       # local basemap
       if(dir.exists(file.path(wopr_dir,'basemap'))){
         addResourcePath('basemap', file.path(wopr_dir,'basemap'))
       }
     })
-
+    
     ## leaflet map
     output$map <- leaflet::renderLeaflet({
       map(country = rv$country,
@@ -116,18 +131,18 @@ shinyServer(
           pal = rv$pal,
           dict = rv$dict)
     })
-
+    
     ## change location selection tool
     observeEvent(input$pointpoly,{
-
+      
       rv$N <- rv$agesexid <- NULL
-
+      
       mapProxyPoly(input$pointpoly)
-
+      
       if(input$pointpoly=='Upload File'){
-
+        
         shinyjs::enable('user_json')
-
+        
         if(is.null(input$user_json)){
           shinyjs::disable('submit')
         }
@@ -136,35 +151,35 @@ shinyServer(
         shinyjs::disable('submit')
       }
     })
-
+    
     ## age-sex selection
     observeEvent(c(input$male, input$female, input$male_select, input$female_select), {
       rv$N <- rv$agesexid <- NULL
       rv$agesex_select <- agesexLookup(input$male, input$female, input$male_select, input$female_select)
     })
-
+    
     ## file upload
     observeEvent(input$user_json, {
       geojson_limit <- 45
-
+      
       if(!is.null(input$user_json)){
-
+        
         tryCatch({
           updateSelectInput(session, 'pointpoly', selected='Upload File')
-
+          
           rv$feature <- sf::st_read(input$user_json[,'datapath'], quiet=T)
-
+          
           if(nrow(rv$feature) > geojson_limit){
             rv$feature <- rv$feature[1:min(geojson_limit, nrow(rv$feature)),]
             showNotification(paste(rv$dict[["lg_gjson_limit1"]],geojson_limit,rv$dict[["lg_gjson_limit2"]]), type='warning', duration=10)
           }
-
+          
           # rv$feature <- rv$feature[,1]
-
+          
           rv$feature <- sf::st_transform(rv$feature, crs=4326)
-
+          
           mapProxyFile(rv$feature)
-
+          
         }, warning=function(w){
           shinyjs::reset('user_json')
           showNotification(as.character(w), type='warning', duration=20)
@@ -174,7 +189,7 @@ shinyServer(
         })
       }
     })
-
+    
     ## map click
     observeEvent(input$map_click, {
       if(input$pointpoly=='Selected Point'){
@@ -183,7 +198,7 @@ shinyServer(
         rv$feature <- leaf_sf(input$map_click, input$pointpoly)
       }
     })
-
+    
     ## draw polygon
     observeEvent(input$map_draw_all_features, {
       if(input$pointpoly=='Custom Area'){
@@ -191,7 +206,7 @@ shinyServer(
         rv$feature <- leaf_sf(input$map_draw_all_features, input$pointpoly)
       }
     })
-
+    
     # toggle submit button
     observeEvent(rv$feature, {
       if(is.null(rv$feature)){
@@ -200,7 +215,7 @@ shinyServer(
         shinyjs::enable('submit')
       }
     })
-
+    
     # toggle save button
     observe({
       if(is.null(rv$N) | input$pointpoly=='Upload File'){
@@ -211,49 +226,49 @@ shinyServer(
         updateCheckboxInput(session, 'toggle_plots', value=T)
       }
     })
-
+    
     ##-- query wopr --##
     observeEvent(input$submit, {
-
+      
       shinyjs::disable('submit')
-
+      
       rv$N <- rv$agesexid <- NA
-
+      
       if(class(rv$feature)[1]=='sf'){
-
+        
         withProgress({
           tryCatch({
-
+            
             if(input$pointpoly=='Upload File'){
-
+              
               # Upload File
               feature <- woprize(feature=rv$feature,
-                                    country=rv$country,
-                                    version=rv$version,
-                                    agesex_select=rv$agesex_select,
-                                    confidence=input$ci_level/1e2,
-                                    tails=ifelse(input$ci_type=='Interval',2,1),
-                                    abovethresh=input$popthresh,
-                                    url=url)
-
+                                 country=rv$country,
+                                 version=rv$version,
+                                 agesex_select=rv$agesex_select,
+                                 confidence=input$ci_level/1e2,
+                                 tails=ifelse(input$ci_type=='Interval',2,1),
+                                 abovethresh=input$popthresh,
+                                 url=url)
+              
               # get settings for woprized features
               ct <- resultTable(input, rv)
-
+              
               # keep only settings (remove results)
               ct <- ct[,c('data','female_age','male_age','confidence_level','confidence_type','popthresh')]
-
+              
               # rename columns
               names(feature)[names(feature)=='mean'] <- 'pop_mean'
               names(feature)[names(feature)=='median'] <- 'pop_median'
               names(feature)[names(feature)=='lower'] <- 'pop_lower'
               names(feature)[names(feature)=='upper'] <- 'pop_upper'
-
+              
               # remove unwanted columns
               for(name in c('belowthresh','agesexid')) feature[,name] <- NULL
-
+              
               # add settings to woprized results
               feature[,names(ct)] <- ct
-
+              
               # modal to download results
               showModal(modalDialog(rv$dict[['lg_gson_download']],
                                     footer = tagList(
@@ -262,7 +277,7 @@ shinyServer(
                                       modalButton(rv$dict[['lg_close']])),
                                     title = 'Results')
               )
-
+              
               # download results as geojson
               output$download_geojson <- downloadHandler(
                 filename = function() {
@@ -275,7 +290,7 @@ shinyServer(
                                quiet = TRUE)
                 },
                 contentType = 'application/json')
-
+              
               # download results as csv
               output$download_spreadsheet <- downloadHandler(
                 filename = function() {
@@ -287,15 +302,15 @@ shinyServer(
                             row.names = FALSE)
                 },
                 contentType = 'application/json')
-
+              
               # shinyjs::reset('user_json')
               # mapProxyFile()
               # rv$feature <- NULL
             }
-
+            
             if(input$pointpoly %in% c('Selected Point', 'Custom Area')) {
               if(version_info[input$data_select,'local_sql']){
-
+                
                 # query local SQL
                 i <- getPopSql(cells=cellids(rv$feature, rv$mastergrid),
                                db=rv$sql,
@@ -304,9 +319,9 @@ shinyServer(
                                get_agesexid=T)
                 rv$N <- i[['N']]
                 rv$agesexid <- as.character(i[['agesexid']])
-
+                
               } else {
-
+                
                 # query wopr
                 i <- getPop(feature=rv$feature,
                             country=rv$country,
@@ -318,19 +333,19 @@ shinyServer(
                 rv$agesexid <- as.character(i[['agesexid']])
               }
             }
-
+            
           }, warning=function(w){
-
+            
             showNotification(as.character(w), type='warning', duration=20)
-
+            
             if(input$pointpoly=='Upload File') shinyjs::reset('user_json')
-
+            
           }, error=function(e){
-
+            
             showNotification(as.character(e), type='error', duration=20)
-
+            
             if(input$pointpoly=='Upload File') shinyjs::reset('user_json')
-
+            
           })
         }, message='woprizing:',
         detail=rv$dict[['lg_woprizing_message']],
@@ -338,10 +353,10 @@ shinyServer(
       }
       shinyjs::enable('submit')
     })
-
+    
     ##-- create plot --##
     output$sidePlot <- renderPlot({
-
+      
       plotPanel(N=rv$N,
                 agesex_select=rv$agesex_select,
                 agesex_table=agesex[[input$data_select]][rv$agesexid,],
@@ -351,36 +366,36 @@ shinyServer(
                 popmax=version_info[input$data_select,'popmax'],
                 dict=rv$dict)
     })
-
+    
     # save button
     observeEvent(input$save_button, {
-
+      
       if(!is.null(rv$N) & !is.null(rv$feature)){
         ct <- resultTable(input, rv)
-
+        
         if(!'table' %in% names(rv)){
           rv$table <- ct
         } else {
           rv$table <- rbind(ct, rv$table)
         }
         row.names(rv$table) <- 1:nrow(rv$table)
-
+        
         showNotification(rv$dict[['lg_saving_message']], type='message', duration=10)
       } else {
         showNotification(rv$dict[['lg_saving_eror']], type='message')
       }
       shinyjs::reset('save_name')
     })
-
+    
     ##-- saved tab --##
-
+    
     # results table
     output$results_table <- renderTable( rv$table[,-which(names(rv$table) %in% c('message','geojson'))],
                                          digits = 3,
                                          striped = T,
                                          format.args = list(big.mark=",", decimal.mark="."),
                                          rownames = F)
-
+    
     # download button
     output$download_table <- downloadHandler(filename = function(timestamp=format(Sys.time(), "%Y%m%d%H%M")) paste0('woprVision_',timestamp,'.csv'),
                                              content = function(file) {
@@ -413,12 +428,12 @@ shinyServer(
         shinyjs::enable('clear_button')
       }
     })
-
+    
     ##-- translation --##
     observeEvent(input$lang_select, {
-
+      
       rv$N <- rv$agesexid <- NULL
-
+      
       translate <- function(str){
         if(input$lang_select=="FR") {
           output[[str]] <- renderUI(dict_fr[[str]])
@@ -431,12 +446,12 @@ shinyServer(
         } else {
           output[[str]] <- renderUI(dict_en[[str]])
         }
-
+        
         # output[[str]] <- renderUI(ifelse(input$lang_select=="FR", dict_fr[[str]], dict_en[[str]] ))
       }
-
+      
       lapply(keys[!grepl("helpfile", keys)], function(u) translate(u))
-
+      
       if(input$lang_select=="FR"){
         rv$dict <- dict_fr
       } else if(input$lang_select=="PT") {
@@ -448,7 +463,7 @@ shinyServer(
       } else {
         rv$dict <- dict_en
       }
-
+      
       # specific case: confidence type
       output$confidence_type <- renderText(
         return(paste0(
@@ -464,10 +479,10 @@ shinyServer(
         ))
       )
     })
-
-
+    
+    
     ##-- tabs --##
-
+    
     # help tab
     observeEvent(input$lang_select,{
       output$helpfile <- renderText(
@@ -475,18 +490,19 @@ shinyServer(
                      rv$dict[["lg_helpfile"]], '", frameBorder="0"></iframe>', sep = ""))
       )
     })
-
+    
     # wopr download tab
     observeEvent(input$download_link, {
       showModal(modalDialog(HTML(paste0(input$data_select, rv$dict[['lg_download_popup']],a(href=rv$wopr_url, target='_blank', rv$wopr_url))),
                             title = rv$dict[['lg_data_download']])
       )
     })
-
+    
     # readme tab
     output$data_readme <- renderText(
       return(paste('<iframe style="height: calc(97vh - 80px); width:100%" src="', rv$data_readme_url, '", frameBorder="0"></iframe>', sep = ""))
     )
+    
   })
 
 

--- a/inst/woprVision/ui.R
+++ b/inst/woprVision/ui.R
@@ -116,7 +116,7 @@ ui <- fluidPage(
                          width="80px", 
                          selectize = T)),
     
-    navbarPage(title='woprVision (beta)',
+    navbarPage(title=a(href='https://apps.worldpop.org/woprVision/', target='_self', style='color: #777777; text-decoration: none', 'woprVision (beta)'),
                footer=tags$footer(HTML(paste0('Source data: <a href="https://wopr.worldpop.org" target="_blank">WorldPop Open Population Repository (WOPR)</a>, Source code: <a href="https://github.com/wpgp/wopr" target="_blank">wopr R package v',packageVersion('wopr'),'</a>')), align='right'),
                inverse=F,
                id="navbar_id",


### PR DESCRIPTION
Goal: being able to distribute urls to specific datasets.
Implementation: 
1.	The url should be similar to that: “127.0.0.1:7797/?data_select=MOZ_v1.1”
2.	If the dataset is misspelled nothing is happening – but I could change it such that the app is broken: would you prefer?
3.	It is internally changed to data_select=”MOZ_v1.1” and use to update the dropdown menu of data_select such that
a.	The dataset selected trickles down in the entire app
b.	There’s no option anymore to change the input dataset
4.	An invisible hyperlink is added to the navbar title woprVision (beta) that redirects to https://apps.worldpop.org/woprVision/ such that
a.	Different datatsets can be selected
b.	The url is reset to its default version when the app is deployed.
