### PR TITLE
error handling for getAgeSexTable

### DIFF
--- a/R/getAgeSexTable.R
+++ b/R/getAgeSexTable.R
@@ -26,6 +26,10 @@ getAgeSexTable <- function(country, version=NA, locator='https://api.worldpop.or
   
   response <- httr::content( httr::POST(url=endpoint, body=request, encode="form"), as='parsed')
   
+  if(response$error) {
+    warning(response$error_message, call.=F)
+  }
+  
   table <- data.frame(do.call(rbind.data.frame, response$data))
   table$id <- names(response$data)
 

--- a/inst/woprVision/server.R
+++ b/inst/woprVision/server.R
@@ -141,17 +141,23 @@ shinyServer(
       }
 
       # age sex table
-      if(version_info[input$data_select, 'local_agesex_table']){
-        
-        showNotification(paste(rv$dict[["lg_localagesex"]], input$data_select), type='message') # message(paste0('Using local image tiles for ',input$data_select,'.')) 
-        
-        rv$agesex_table <- getAgeSexTable(rv$country, rv$version, version_info[input$data_select, 'local_agesex_table_path'])
-        
-      } else {
-        
-        rv$agesex_table <- getAgeSexTable(rv$country, rv$version, locator=url)
-        
-      }
+      tryCatch({
+
+        if(version_info[input$data_select, 'local_agesex_table']){
+          
+          showNotification(paste(rv$dict[["lg_localagesex"]], input$data_select), type='message') # message(paste0('Using local image tiles for ',input$data_select,'.')) 
+          rv$agesex_table <- getAgeSexTable(rv$country, rv$version, version_info[input$data_select, 'local_agesex_table_path'])
+          
+        } else {
+          
+          rv$agesex_table <- getAgeSexTable(rv$country, rv$version, locator=url)
+          
+        }
+      }, warning=function(w){
+        showNotification(as.character(w), type='warning', duration=20)
+      }, error=function(e){
+        showNotification(as.character(e), type='error', duration=20)
+      })
       
       # local basemap
       if(dir.exists(file.path(wopr_dir,'basemap'))){


### PR DESCRIPTION
Suggesting some basic error handling so the Shiny app won't crash if the API request for agesex tables results in an error, and also so that the app user recieves any API error messages as popup notifications.